### PR TITLE
Send agent and controller kel on ipex grant

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,6 @@ setup(
         'pytest>=8.3.4',
     ],
     setup_requires=[
-        'setuptools==75.8.2'
     ],
     entry_points={
         'console_scripts': [

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -675,8 +675,23 @@ class ExchangeSender(doing.DoDoer):
 
 
 class Granter(doing.DoDoer):
+    """
+    Presents ACDC credentials to a recipient using the Grant action of the IPEX protocol
+    by sending all relevant data including delegated KELs and chained ACDCs.
+    """
 
     def __init__(self, hby, rgy, agentHab, exc, grants, tock=0.0):
+        """
+        Accepts a list of IPEX Grant cues to process.
+
+        Parameters:
+            hby (Habery): The Agent Habery.
+            rgy (Regery): The Agent Regery.
+            agentHab (Hab): The Agent Hab.
+            exc (Exchanger): The Exchanger instance for this Agent.
+            grants (decking.Deck): Queue of grant messages to process.
+            tock (float): The time interval for processing grants.
+        """
         self.hby = hby
         self.rgy = rgy
         self.agentHab = agentHab
@@ -685,13 +700,45 @@ class Granter(doing.DoDoer):
         self.tock = tock
         super(Granter, self).__init__(always=True, tock=self.tock)
 
-    def recur(self, tyme, deeds=None):
+    def sendAgentKEL(self, pre, recp, postman):
+        """Send the KEL of the agent to the recipient."""
+        for msg in self.agentHab.db.cloneDelegation(self.agentHab.kever):
+            serder = serdering.SerderKERI(raw=msg)
+            atc = msg[serder.size:]
+            postman.send(serder=serder, attachment=atc)
+
+    def sendCredArtifacts(self, recp, credSaid, postman):
+        """Send to the recipient the ACDC and the KELs of the issuer, holder, and any delegators."""
+        creder = self.rgy.reger.creds.get(keys=(credSaid,))
+        sendArtifacts(self.hby, self.rgy.reger, postman, creder, recp)
+        self.sendChainedArtifacts(recp, creder, postman)
+
+    def sendChainedArtifacts(self, recp, creder, postman):
+        """
+        Send to the recipient any chained ACDCs and the KELs of the issuers and holders of those
+        ACDCS and the KELs of any of their delegators.
+        """
+        sources = self.rgy.reger.sources(self.hby.db, creder)
+        for source, atc in sources:
+            sendArtifacts(self.hby, self.rgy.reger, postman, source, recp)
+            postman.send(serder=source, attachment=atc)
+
+    def postGrants(self):
+        """
+        Presents an ACDC by sending all relevant data and cryptographic artifacts in the following order:
+        - the agent KEL artifacts, including any delegation chain artifats
+        - the issuer KEL artifacts, including delegation artifacts
+        - the holder KEL artifacts, including delegation artifacts
+        - the ACDC registry artifacts
+        - the ACDC credential itself
+        This is repeated for any chained credentials except that the agent KEL is only sent once.
+        """
         if self.grants:
             msg = self.grants.popleft()
             said = msg['said']
             if not self.exc.complete(said=said):
                 self.grants.append(msg)
-                return super(Granter, self).recur(tyme, deeds)
+                return
 
             serder, pathed = exchanging.cloneMessage(self.hby, said)
 
@@ -702,14 +749,9 @@ class Granter(doing.DoDoer):
                 for recp in rec:
                     postman = forwarding.StreamPoster(hby=self.hby, hab=self.agentHab, recp=recp, topic="credential")
                     try:
+                        self.sendAgentKEL(pre, recp, postman)
                         credSaid = serder.ked['e']['acdc']['d']
-                        creder = self.rgy.reger.creds.get(keys=(credSaid,))
-                        sendArtifacts(self.hby, self.rgy.reger, postman, creder, recp)
-                        sources = self.rgy.reger.sources(self.hby.db, creder)
-                        for source, atc in sources:
-                            sendArtifacts(self.hby, self.rgy.reger, postman, source, recp)
-                            postman.send(serder=source, attachment=atc)
-
+                        self.sendCredArtifacts(recp, credSaid, postman)
                     except kering.ValidationError:
                         logger.info(f"unable to send to recipient={recp}")
                     except KeyError:
@@ -718,6 +760,9 @@ class Granter(doing.DoDoer):
                         doer = doing.DoDoer(doers=postman.deliver())
                         self.extend([doer])
 
+    def recur(self, tyme, deeds=None):
+        """Doer lifecycle method to process grants."""
+        self.postGrants()
         return super(Granter, self).recur(tyme, deeds)
 
 


### PR DESCRIPTION
This resolves the long-standing double present bug where presenting the first credential from KERIA would fail because the destination did not have the agent KEL.

When first presenting a credential from KERIA to something like GLEIF's Sally recipient then you had to do two presentations from a KERIA agent. Somehow this caused the KERIA Agent KEL to get propagated to Sally, yet the first presentation would always fail.

This PR changes that by proactively sending the Agent KEL and its entire delegation chain which includes the Signify controller AID that delegated to the Agent KEL. By sending sending the Agent KEL ahead of time then the first presentation of a credential from KERIA to a destination succeeds the first time, every time.