### PR TITLE
Enhanced logging gleif 0 3 0

### DIFF
--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -53,6 +53,11 @@ from ..core.authing import Authenticater
 from ..core.keeping import RemoteManager
 from ..db import basing
 
+formatter = logging.Formatter('keria: %(asctime)s - %(levelname)s - %(message)s')
+logHandler = logging.StreamHandler()
+logHandler.setFormatter(formatter)
+ogler.baseFormatter = formatter
+ogler.baseConsoleHandler = logHandler
 logger = ogler.getLogger()
 
 @dataclass
@@ -120,11 +125,11 @@ class KERIAServerConfig:
 
 def runAgency(config: KERIAServerConfig):
     """Runs a KERIA Agency with the given Doers by calling Doist.do(). Useful for testing."""
-    help.ogler.level = logging.getLevelName(config.logLevel)
-    logger.setLevel(help.ogler.level)
+    ogler.level = logging.getLevelName(config.logLevel)
+    logger.setLevel(ogler.level)
     if config.logFile is not None:
-        help.ogler.headDirPath = config.logFile
-        help.ogler.reopen(name=config.name, temp=False, clear=True)
+        ogler.headDirPath = config.logFile
+        ogler.reopen(name=config.name, temp=False, clear=True)
 
     logger.info("Starting Agent for %s listening: admin/%s, http/%s, boot/%s",
                 config.name, config.adminPort, config.httpPort, config.bootPort)
@@ -657,10 +662,12 @@ class ExchangeSender(doing.DoDoer):
             rec = msg["rec"]
             topic = msg['topic']
             hab = self.hby.habs[pre]
+            logger.debug("[%s | %s...%s]: Current Message Body= %s", hab.name, hab.pre[:4], hab.pre[-4:], msg);
             if self.exc.lead(hab, said=said):
                 atc = exchanging.serializeMessage(self.hby, said)
                 del atc[:serder.size]
                 for recp in rec:
+                    logger.debug("[%s | %s...%s]: Sending on topic %s to recipient %s from %s", hab.name, hab.pre[:4], hab.pre[-4:], topic, recp, pre)
                     postman = forwarding.StreamPoster(hby=self.hby, hab=self.agentHab, recp=recp, topic=topic)
                     try:
                         postman.send(serder=serder,

--- a/src/keria/app/agenting.py
+++ b/src/keria/app/agenting.py
@@ -53,7 +53,23 @@ from ..core.authing import Authenticater
 from ..core.keeping import RemoteManager
 from ..db import basing
 
-formatter = logging.Formatter('keria: %(asctime)s - %(levelname)s - %(message)s')
+
+class TruncatedFormatter(logging.Formatter):
+    """Formats log records with shorter module and function names and a right justified line number for readability."""
+    def __init__(self, fmt=None, datefmt=None, style='%'):
+        super().__init__(fmt, datefmt, style)
+
+    def format(self, record):
+        # Truncate module and funcName to first 'chars' characters
+        mod_chars = 10 # number of spaces to truncate to
+        fn_chars = 14 # number of spaces to truncate to
+        record.module = (record.module[:mod_chars] + ' ' * mod_chars)[:mod_chars]
+        record.funcName = (record.funcName[:fn_chars] + ' ' * fn_chars)[:fn_chars]
+        record.lineno = str(record.lineno).rjust(5)  # Ensure line number is right-aligned
+        return super().format(record)
+
+formatter = TruncatedFormatter('%(asctime)s [keria] %(levelname)-8s %(module)s.%(funcName)s-%(lineno)s %(message)s')
+formatter.default_msec_format = None
 logHandler = logging.StreamHandler()
 logHandler.setFormatter(formatter)
 ogler.baseFormatter = formatter
@@ -129,7 +145,7 @@ def runAgency(config: KERIAServerConfig):
     logger.setLevel(ogler.level)
     if config.logFile is not None:
         ogler.headDirPath = config.logFile
-        ogler.reopen(name=config.name, temp=False, clear=True)
+        ogler.reopen(name="keria", temp=False, clear=True)
 
     logger.info("Starting Agent for %s listening: admin/%s, http/%s, boot/%s",
                 config.name, config.adminPort, config.httpPort, config.bootPort)

--- a/src/keria/app/aiding.py
+++ b/src/keria/app/aiding.py
@@ -834,6 +834,8 @@ class IdentifierResourceEnd:
                 title="invalid rotation",
                 description=f"required field 'rot' missing from request",
             )
+        serder = serdering.SerderKERI(sad=rot)
+        logger.info("[%s | %s...%s]: Rotation event sn=%s SAID=%s", hab.name, hab.pre[:4], hab.pre[-4:], serder.sn, serder.said)
 
         if "ba" in rot:
             for wit in rot["ba"]:
@@ -847,8 +849,6 @@ class IdentifierResourceEnd:
                 title="invalid rotation",
                 description=f"required field 'sigs' missing from request",
             )
-
-        serder = serdering.SerderKERI(sad=rot)
         sigers = [core.Siger(qb64=sig) for sig in sigs]
 
         if Algos.salty in body:
@@ -931,6 +931,8 @@ class IdentifierResourceEnd:
                 title="invalid interaction",
                 description=f"required field 'ixn' missing from request",
             )
+        serder = serdering.SerderKERI(sad=ixn)
+        logger.info("[%s | %s...%s] Interaction event sn=%s SAID=%s", hab.name, hab.pre[:4], hab.pre[-4:], serder.sn, serder.said)
 
         sigs = body.get("sigs")
         if sigs is None or len(sigs) == 0:
@@ -939,7 +941,6 @@ class IdentifierResourceEnd:
                 description=f"required field 'sigs' missing from request",
             )
 
-        serder = serdering.SerderKERI(sad=ixn)
         sigers = [core.Siger(qb64=sig) for sig in sigs]
 
         hab.interact(serder=serder, sigers=sigers)
@@ -975,6 +976,7 @@ class IdentifierResourceEnd:
             raise falcon.HTTPNotFound(title=f"No AID {name} found")
 
         code = body.get("code")
+        logger.info("[%s | %s...%s]: Resubmit event code=%s", name, hab.pre[:4], hab.pre[-4:], code)
 
         if hab.kever.wits:
             agent.submits.append(dict(alias=name, code=code))

--- a/src/keria/app/cli/commands/start.py
+++ b/src/keria/app/cli/commands/start.py
@@ -6,7 +6,9 @@ keria.cli.keria.commands.start module
 KERIA Agent server start command line interface (CLI) command
 """
 import argparse
+import logging
 import os
+
 
 from keri import __version__
 from keri import help
@@ -77,6 +79,7 @@ parser.add_argument("--experimental-boot-username",
 
 
 logger = help.ogler.getLogger()
+
 
 def launch(args):
     agenting.runAgency(agenting.KERIAServerConfig(

--- a/src/keria/app/credentialing.py
+++ b/src/keria/app/credentialing.py
@@ -9,7 +9,7 @@ import json
 from dataclasses import asdict
 
 import falcon
-from keri import kering
+from keri import kering, help
 from keri.app import signing
 from keri.app.habbing import SignifyGroupHab
 from keri.core import coring, scheming, serdering
@@ -19,6 +19,8 @@ from keri.vdr import viring
 
 from keria.core import httping, longrunning
 
+
+logger = help.ogler.getLogger()
 
 def loadEnds(app, identifierResource):
     schemaColEnd = SchemaCollectionEnd()
@@ -1022,8 +1024,22 @@ def signPaths(hab, pather, sigers):
 
 
 class Registrar:
+    """
+    Manages credential registry creation (inception), credential issuance, and credential revocation.
+    Handles witness, multisig, and dissemination escrows for registry and credential operations.
+    """
 
     def __init__(self, agentHab, hby, rgy, counselor, witDoer, witPub, verifier):
+        """
+        Parameters:
+            hby (habbing.Habery): Habery in which the Agent lives
+            agentHab (habbing.Habitat): Agent
+            rgy (Regery): registry for the agent
+            counselor (Counselor): counselor for the agent
+            witDoer (WitnessReceiptor): retrieves receipts registry and credential events from witnesses
+            witPub (WitnessPublisher): publishes registry and credential events to witnesses
+            verifier (Verifier): Verifies TEL events
+        """
         self.hby = hby
         self.agentHab = agentHab
         self.rgy = rgy
@@ -1056,7 +1072,7 @@ class Registrar:
             self.rgy.reger.tpwe.add(keys=(registry.regk, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
 
         else:
-            print("Waiting for TEL registry vcp event mulisig anchoring event")
+            logger.info("[%s | %s...%s]: Waiting for TEL registry vcp event mulisig anchoring event", hab.name, hab.pre[:4], hab.pre[-4:])
             self.rgy.reger.tmse.add(keys=(registry.regk, rseq.qb64, registry.regd), val=(prefixer, seqner, saider))
 
     def issue(self, regk, iserder, anc):
@@ -1081,7 +1097,7 @@ class Registrar:
             saider = coring.Saider(qb64=hab.kever.serder.said)
             registry.anchorMsg(pre=vcid, regd=iserder.said, seqner=seqner, saider=saider)
 
-            print("Waiting for TEL event witness receipts")
+            logger.info("[%s | %s...%s]: Waiting for TEL event witness receipts", hab.name, hab.pre[:4], hab.pre[-4:])
             self.witDoer.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
             self.rgy.reger.tpwe.add(keys=(vcid, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
             return vcid, rseq.sn
@@ -1094,7 +1110,7 @@ class Registrar:
             seqner = coring.Seqner(sn=sn)
             saider = coring.Saider(qb64=said)
 
-            print(f"Waiting for TEL iss event mulisig anchoring event {seqner.sn}")
+            logger.info("[%s | %s...%s]: Waiting for TEL iss event mulisig anchoring event %s", hab.name, hab.pre[:4], hab.pre[-4:], seqner.sn)
             self.rgy.reger.tmse.add(keys=(vcid, rseq.qb64, iserder.said), val=(prefixer, seqner, saider))
             return vcid, rseq.sn
 
@@ -1120,7 +1136,7 @@ class Registrar:
             saider = coring.Saider(qb64=hab.kever.serder.said)
             registry.anchorMsg(pre=vcid, regd=rserder.said, seqner=seqner, saider=saider)
 
-            print("Waiting for TEL event witness receipts")
+            logger.info("[%s | %s...%s]: Waiting for TEL event witness receipts", hab.name, hab.pre[:4], hab.pre[-4:])
             self.witDoer.msgs.append(dict(pre=hab.pre, sn=seqner.sn))
 
             self.rgy.reger.tpwe.add(keys=(vcid, rseq.qb64), val=(hab.kever.prefixer, seqner, saider))
@@ -1136,7 +1152,7 @@ class Registrar:
 
             self.counselor.start(prefixer=prefixer, seqner=seqner, saider=saider, ghab=hab)
 
-            print(f"Waiting for TEL rev event mulisig anchoring event {seqner.sn}")
+            logger.info(f"[%s | %s...%s]: Waiting for TEL rev event mulisig anchoring event %s", hab.name, hab.pre[:4], hab.pre[-4:], seqner.sn)
             self.rgy.reger.tmse.add(keys=(vcid, rseq.qb64, rserder.said), val=(prefixer, seqner, saider))
             return vcid, rseq.sn
 
@@ -1233,7 +1249,7 @@ class Registrar:
             for msg in self.rgy.reger.clonePreIter(pre=regk, fn=rseq.sn):
                 tevt.extend(msg)
 
-            print(f"Sending TEL events to witnesses")
+            logger.info(f"Sending TEL events to witnesses")
             # Fire and forget the TEL event to the witnesses.  Consumers will have to query
             # to determine when the Witnesses have received the TEL events.
             self.witPub.msgs.append(dict(pre=prefixer.qb64, msg=tevt))

--- a/src/keria/app/delegating.py
+++ b/src/keria/app/delegating.py
@@ -1,7 +1,7 @@
 import falcon
 
 from hio.base import doing
-from keri import kering
+from keri import kering, help
 from keri.app import forwarding, agenting, habbing
 from keri.core import coring, serdering
 from keri.db import dbing
@@ -9,6 +9,8 @@ from keri.db import dbing
 from keria.core import httping, longrunning
 
 DELEGATION_ROUTE = "/identifiers/{name}/delegation"
+
+logger = help.ogler.getLogger()
 
 def loadEnds(app, identifierResource):
     gatorEnd = DelegatorEnd(identifierResource)
@@ -29,11 +31,8 @@ class Anchorer(doing.DoDoer):
         gather all receipts and send them to all other witnesses
 
         Parameters:
-            hab (Hab): Habitat of the identifier to populate witnesses
-            msg (bytes): is the message to send to all witnesses.
-                 Defaults to sending the latest KEL event if msg is None
-            scheme (str): Scheme to favor if available
-
+            hby (Habery): Habery of the agent to populate witnesses
+            proxy (Hab): Agent Hab to use as a messaging proxy to send messages to the delegator on behalf of SignifyHab instances as SignifyHabs cannot sign messages in a KERIA Agent.
         """
         self.hby = hby
         self.postman = forwarding.Poster(hby=hby)
@@ -132,7 +131,7 @@ class Anchorer(doing.DoDoer):
                 self.hby.db.setAes(dgkey, couple)  # authorizer event seal (delegator/issuer)
 
                 # Move to escrow waiting for witness receipts
-                print(f"Delegation approval received,  {serder.pre} confirmed")
+                logger.info("[%s...%s]: Delegation approval received, %s confirmed", pre[:4], pre[-4:], serder.pre)
                 self.hby.db.cdel.put(keys=(pre, coring.Seqner(sn=serder.sn).qb64), val=coring.Saider(qb64=serder.said))
                 self.hby.db.dune.rem(keys=(pre, said))
 
@@ -160,7 +159,7 @@ class Anchorer(doing.DoDoer):
                             witnessed = True
                     if not witnessed:
                         continue
-                print(f"Witness receipts complete, waiting for delegation approval.")
+                logger.info("[%s...%s]: Witness receipts complete, waiting for delegation approval for %s", pre[:4], pre[-4:], serder.pre)
                 if isinstance(hab, habbing.GroupHab):
                     phab = hab.mhab
                 elif self.proxy is not None:
@@ -168,7 +167,7 @@ class Anchorer(doing.DoDoer):
                 elif hab.kever.sn > 0:
                     phab = hab
                 else:
-                    raise kering.ValidationError("no proxy to send messages for delegation")
+                    raise kering.ValidationError("No proxy to send messages for delegation for AID [%s...%s]", pre[:4], pre[-4:])
 
                 evt = hab.db.cloneEvtMsg(pre=serder.pre, fn=0, dig=serder.said)
 
@@ -180,7 +179,7 @@ class Anchorer(doing.DoDoer):
                 self.hby.db.dune.pin(keys=(srdr.pre, srdr.said), val=srdr)
                 
 class DelegatorEnd:
-    """ Resource class for for handling delegator events"""
+    """ Resource class for handling delegator events"""
     
     def __init__(self, identifierResource) -> None:
         """
@@ -192,7 +191,7 @@ class DelegatorEnd:
         self.identifierResource = identifierResource
 
     def on_post(self, req, rep, name):
-        """ Identifier delegator enpoint POST to create the ixn anchor and approve the delegation
+        """ Identifier delegator endpoint POST to create the ixn anchor and approve the delegation
 
         Parameters:
             req (Request): falcon.Request HTTP request object

--- a/src/keria/app/grouping.py
+++ b/src/keria/app/grouping.py
@@ -52,11 +52,15 @@ class MultisigRequestCollectionEnd:
         if not isinstance(hab, habbing.SignifyGroupHab):
             raise falcon.HTTPBadRequest(description=f"hab for alias or prefix {name} is not a multisig")
 
+
         # grab all of the required parameters
         ked = httping.getRequiredParam(body, "exn")
         serder = serdering.SerderKERI(sad=ked)
         sigs = httping.getRequiredParam(body, "sigs")
         atc = httping.getRequiredParam(body, "atc")
+
+        logger.info("[%s | %s...%s]: Posting EXN on Route %s event %s", name, hab.pre[:4], hab.pre[-4:], ked["r"], ked["d"])
+        logger.debug("EXN: %s", json.dumps(body))
 
         # create sigers from the edge signatures so we can messagize the whole thing
         sigers = [core.Siger(qb64=sig) for sig in sigs]
@@ -77,6 +81,7 @@ class MultisigRequestCollectionEnd:
         if hab.mhab.pre in smids:
             smids.remove(hab.mhab.pre)
 
+        logger.info("[%s | %s...%s]: new exchange message %s", name, hab.pre[:4], hab.pre[-4:], json.dumps(dict(said=serder.said, pre=hab.pre, rec=smids, topic='multisig')))
         agent.exchanges.append(dict(said=serder.said, pre=hab.pre, rec=smids, topic='multisig'))
 
         rep.status = falcon.HTTP_200

--- a/src/keria/app/serving.py
+++ b/src/keria/app/serving.py
@@ -11,14 +11,12 @@ class GracefulShutdownDoer(doing.Doer):
     Sets up signal handler in the Doer.enter lifecycle method and exits the Doist scheduler loop in Doer.exit
     Checks for the shutdown flag being set in the Doer.recur lifecycle method.
     """
-    def __init__(self, doist, agency, **kwa):
+    def __init__(self, agency, **kwa):
         """
         Parameters:
-            doist (Doist): The Doist running this Doer
             agency (Agency): The Agency containing Agent instances to be gracefully shut down
             kwa (dict): Additional keyword arguments for Doer initialization
         """
-        self.doist: Doist = doist
         self.agency = agency
         self.shutdown_received = False
 
@@ -27,6 +25,11 @@ class GracefulShutdownDoer(doing.Doer):
     def handle_sigterm(self, signum, frame):
         """Handler function for SIGTERM"""
         logger.info(f"Received SIGTERM, initiating graceful shutdown.")
+        self.shutdown_received = True
+
+    def handle_sigint(self, signum, frame):
+        """Handler function for SIGINT"""
+        logger.info(f"Received SIGINT, initiating graceful shutdown.")
         self.shutdown_received = True
 
     def shutdown_agents(self, agents):
@@ -42,6 +45,7 @@ class GracefulShutdownDoer(doing.Doer):
         """
         # Register signal handler
         signal.signal(signal.SIGTERM, self.handle_sigterm)
+        signal.signal(signal.SIGINT, self.handle_sigint)
         logger.info("Registered signal handlers for SIGTERM")
 
     def recur(self, tock=0.0):
@@ -50,9 +54,8 @@ class GracefulShutdownDoer(doing.Doer):
         while not self.shutdown_received:
             yield tock # will iterate forever in here until shutdown flag set
 
+        logger.info("Shutdown flag received, initiating graceful shutdown of agents")
         # Once shutdown_flag is set, exit the Doist loop
-        self.shutdown_agents(list(self.agency.agents.keys()))
-
         return True # Returns a "done" status
         # Causes the Doist scheduler to call .exit() lifecycle method below, killing the doist loop
 
@@ -61,5 +64,6 @@ class GracefulShutdownDoer(doing.Doer):
         Exits the Doist loop.
         Lifecycle method called once when the Doist running this Doer exits the context for this Doer.
         """
-        logger.info(f"Shutting down main Doist loop")
-        self.doist.exit()
+        logger.info("Shutting down all agents in the Agency")
+        self.shutdown_agents(list(self.agency.agents.keys()))
+        raise KeyboardInterrupt()

--- a/src/keria/peer/exchanging.py
+++ b/src/keria/peer/exchanging.py
@@ -10,8 +10,10 @@ import falcon
 from keri import core
 from keri.core import coring, eventing, serdering
 from keri.peer import exchanging
-
+from keri.help import ogler
 from keria.core import httping
+
+logger = ogler.getLogger()
 
 
 def loadEnds(app):
@@ -104,6 +106,9 @@ class ExchangeCollectionEnd:
         serder = serdering.SerderKERI(sad=ked)
         sigers = [core.Siger(qb64=sig) for sig in sigs]
 
+        logger.info("[%s | %s...%s] ExchangeCollectionEnd: route %s received exn %s being sent to [%s]",
+                    name, hab.pre[:4], hab.pre[-4:], serder.ked['r'], serder.said, ", ".join(rec))
+
         # Now create the stream to send, need the signer seal
         kever = hab.kever
         seal = eventing.SealEvent(i=hab.pre, s="{:x}".format(kever.lastEst.s), d=kever.lastEst.d)
@@ -118,6 +123,8 @@ class ExchangeCollectionEnd:
 
         msg = dict(said=serder.said, pre=hab.pre, rec=rec, topic=topic)
 
+        logger.info("[%s | %s...%s] ExchangeCollectionEnd: appending %s",
+                    name, hab.pre[:4], hab.pre[-4:], json.dumps(msg))
         agent.exchanges.append(msg)
 
         rep.status = falcon.HTTP_202


### PR DESCRIPTION
adds enhanced logging for KERIA and fixes the graceful shutdown handler.

Log messages now look like this:
```
$ keria start --config-dir scripts --config-file keria --loglevel INFO
2025-05-28 11:07:55 [keria] INFO     agenting  .runAgency     -  148 Starting Agent for keria listening: admin/3901, http/3902, boot/3903
2025-05-28 11:07:55 [keria] INFO     agenting  .runAgency     -  150 PID: 62460
2025-05-28 11:07:55 [keria] INFO     agenting  .setupDoers    -  259 The Agency is loaded and waiting for requests...
2025-05-28 11:07:55 [keria] INFO     serving   .enter         -   49 Registered signal handlers for SIGTERM
2025-05-28 11:08:57 [keria] INFO     serving   .handle_sigint -   32 Received SIGINT, initiating graceful shutdown.
2025-05-28 11:08:57 [keria] INFO     serving   .recur         -   57 Shutdown flag received, initiating graceful shutdown of agents
2025-05-28 11:08:57 [keria] INFO     serving   .exit          -   67 Shutting down all agents in the Agency
2025-05-28 11:08:57 [keria] INFO     serving   .shutdown_agent-   37 Stopping 0 agents
2025-05-28 11:08:57 [keria] INFO     start     .launch        -  107 Agent keria gracefully stopped
```